### PR TITLE
feature: add authlib-injector support

### DIFF
--- a/worker/services/cache/cloudflare.ts
+++ b/worker/services/cache/cloudflare.ts
@@ -1,6 +1,6 @@
 // CloudflareCacheService is an implementation of a cache service that
 // uses the Cache API of the Cloudflare Worker.
-const BASE_URL = `https://crafthead.net/`
+declare const BASE_URL: string
 
 interface CloudflareResponseMapper<T> {
     decode(response: Response): Promise<T>;


### PR DESCRIPTION
> authlib-injector enables you to build a Minecraft authentication system offering all the features that genuine Minecraft has.

authlib-injector: <https://github.com/yushijinhun/authlib-injector>
Do `wrangler secret put API_ROOT` to set API root (or will query from Mojang servers by default).
More info on `@mojang` suffix to force query from Mojang servers: <https://github.com/yushijinhun/authlib-injector/pull/28>

**BREAKING CHANGES:**
`BASE_URL` needs to be set with `wrangler secret put BASE_URL`.