### PR TITLE
Request profiles unsigned

### DIFF
--- a/worker/services/mojang/api.ts
+++ b/worker/services/mojang/api.ts
@@ -50,7 +50,7 @@ export class DirectMojangApiService implements MojangApiService {
     }
 
     async fetchProfile(id: string): Promise<MojangProfile | null> {
-        const profileResponse = await fetch(`https://sessionserver.mojang.com/session/minecraft/profile/${id}`, {
+        const profileResponse = await fetch(`https://sessionserver.mojang.com/session/minecraft/profile/${id}?unsigned=false`, {
             cf: {
                 cacheEverything: true,
                 cacheTtl: MOJANG_API_TTL


### PR DESCRIPTION
This is more what I had in mind for #9, similar to our discussion on Discord about Crafthead and its use for copying skins. Users would require need Crafthead to return the `value`/`signature` of the provided profile in question in order to get the right data from Mojang.

[Without `unsigned=false` this data is useless for this](https://wiki.vg/Mojang_API#UUID_-.3E_Profile_.2B_Skin.2FCape) 

Someone with a bit more knowledge of Cloudflare Workers (or, me with a little bit more patience) could pass the flags provided by the user to this URL and only use unsigned=false if the user specifically wants it. Otherwise, I'll just assume that everyone wants it.

Feel free to make an example request to Mojang for the `Char` user to view the difference:

Unsigned unset (defaults to true): 
https://sessionserver.mojang.com/session/minecraft/profile/ef774d96035041b9954d5560baa8ff2a

Unsigned false:
https://sessionserver.mojang.com/session/minecraft/profile/ef774d96035041b9954d5560baa8ff2a?unsigned=false