### PR TITLE
Add body rendering

### DIFF
--- a/src/skin.rs
+++ b/src/skin.rs
@@ -130,7 +130,7 @@ impl MinecraftSkin {
             false => Layer::Bottom
         };
 
-        let mut image = RgbaImage::new( 16, 32);
+        let mut image = RgbaImage::new(16, 32);
 
         imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Head), 4, 0);
         imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Body), 4, 8);

--- a/src/skin.rs
+++ b/src/skin.rs
@@ -3,7 +3,7 @@ extern crate image;
 use image::{DynamicImage, GenericImageView, Rgba, RgbaImage, imageops};
 use imageproc::geometric_transformations::{Projection, Interpolation, warp_into};
 use crate::skin::Layer::Bottom;
-use crate::skin::BodyPart::{ArmRight, LegRight, Body, Head};
+use crate::skin::BodyPart::{ArmLeft, LegLeft, Body, Head};
 use crate::utils::{apply_minecraft_transparency, fast_overlay};
 
 pub(crate) struct MinecraftSkin(DynamicImage);
@@ -70,20 +70,20 @@ impl MinecraftSkin {
                 match part {
                     BodyPart::Head => self.0.crop_imm(8, 8, 8, 8),
                     BodyPart::Body => self.0.crop_imm(20, 20, 8, 12),
-                    BodyPart::ArmLeft => {
+                    BodyPart::ArmRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(36, 52, arm_width, 12),
-                            _                            => self.get_part(Bottom, ArmRight)
+                            _                            => self.get_part(Bottom, ArmLeft).fliph()
                         }
                     },
-                    BodyPart::ArmRight => self.0.crop_imm(44, 20, 4, 12),
-                    BodyPart::LegLeft => {
+                    BodyPart::ArmLeft => self.0.crop_imm(44, 20, 4, 12),
+                    BodyPart::LegRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(20, 52, 4, 12),
-                            _                            => self.get_part(Bottom, LegRight)
+                            _                            => self.get_part(Bottom, LegLeft).fliph()
                         }
                     },
-                    BodyPart::LegRight => self.0.crop_imm(4, 20, 4, 12),
+                    BodyPart::LegLeft => self.0.crop_imm(4, 20, 4, 12),
                 }
             },
             Layer::Top => {
@@ -98,30 +98,48 @@ impl MinecraftSkin {
                     BodyPart::ArmLeft => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(52, 52, arm_width, 12),
-                            _                            => self.get_part(Bottom, ArmRight)
+                            _                            => self.get_part(Bottom, ArmLeft)
                         }
                     },
                     BodyPart::ArmRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(44, 36, arm_width, 12),
-                            _                            => self.get_part(Bottom, ArmRight),
+                            _                            => self.get_part(Bottom, ArmLeft).fliph(),
                         }
                     },
                     BodyPart::LegLeft => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(4, 52, 4, 12),
-                            _                            => self.get_part(Bottom, LegRight),
+                            _                            => self.get_part(Bottom, LegLeft),
                         }
                     },
                     BodyPart::LegRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(4, 36, 4, 12),
-                            _                            => self.get_part(Bottom, LegRight),
+                            _                            => self.get_part(Bottom, LegLeft).fliph(),
                         }
                     },
                 }
             },
         }
+    }
+
+    pub(crate) fn render_body(&self, overlay: bool) -> DynamicImage {
+        let layer_type = match overlay {
+            true  => Layer::Both,
+            false => Layer::Bottom
+        };
+
+        let mut image = RgbaImage::new( 16, 32);
+
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Head), 4, 0);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Body), 4, 8);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmLeft), 0, 8);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmRight), 12, 8);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegLeft), 4, 20);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegRight), 8, 20);
+
+        DynamicImage::ImageRgba8(image)
     }
 
     pub(crate) fn render_cube(&self, overlay: bool, width: u32) -> DynamicImage {

--- a/website/index.html
+++ b/website/index.html
@@ -118,6 +118,20 @@
                 </code>
                 <img src="/cube/48a0a7e4d5594873a617dc189f76a8a1/32" alt="Default example" width="32">
             </div>
+
+            <h3>Fetch a player's body</h3>
+            <div class="example">
+                <code>
+                    GET https://crafthead.net/body/48a0a7e4d5594873a617dc189f76a8a1
+                </code>
+                <img src="/body/48a0a7e4d5594873a617dc189f76a8a1/32" alt="Default example" width="32" height="64">
+            </div>
+            <div class="example">
+                <code>
+                    GET https://crafthead.net/armor/body/Reply
+                </code>
+                <img src="/armor/body/Reply/32" alt="Default example" width="32" height="64">
+            </div>
     
             <h3>Fetch a player's skin</h3>
             <div class="example">

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -92,19 +92,20 @@ async function processRequest(skinService: MojangRequestService, interpreted: Cr
         }
         case RequestedKind.Avatar:
         case RequestedKind.Helm:
-        case RequestedKind.Cube: {
+        case RequestedKind.Cube:
+        case RequestedKind.Body: {
             const skin = await skinService.retrieveSkin(interpreted, gatherer);
-            return renderImage(skin, interpreted.size, interpreted.requested);
+            return renderImage(skin, interpreted.size, interpreted.requested, interpreted.armored);
         }
         case RequestedKind.Skin: {
             return await skinService.retrieveSkin(interpreted, gatherer);
         }
         default:
-            return new Response('must request an avatar, helm, profile, or a skin', { status: 400 });
+            return new Response('must request an avatar, helm, body, profile, or a skin', { status: 400 });
     }
 }
 
-async function renderImage(skin: Response, size: number, requested: RequestedKind.Avatar | RequestedKind.Helm | RequestedKind.Cube): Promise<Response> {
+async function renderImage(skin: Response, size: number, requested: RequestedKind.Avatar | RequestedKind.Helm | RequestedKind.Cube | RequestedKind.Body, armored: boolean): Promise<Response> {
     const destinationHeaders = new Headers(skin.headers);
     const [renderer, skinArrayBuffer] = await Promise.all([getRenderer(), skin.arrayBuffer()]);
     const skinBuf = new Uint8Array(skinArrayBuffer);
@@ -120,11 +121,14 @@ async function renderImage(skin: Response, size: number, requested: RequestedKin
         case RequestedKind.Cube:
             which = "cube";
             break;
+        case RequestedKind.Body:
+            which = "body";
+            break;
         default:
             throw new Error("Unknown requested kind");
     }
 
-    return new Response(renderer.get_minecraft_head(skinBuf, size, which), {
+    return new Response(renderer.get_rendered_image(skinBuf, size, which, armored), {
         headers: destinationHeaders
     });
 }

--- a/worker/request.ts
+++ b/worker/request.ts
@@ -4,6 +4,7 @@ export enum RequestedKind {
     Avatar,
     Helm,
     Cube,
+    Body,
     Profile
 }
 
@@ -18,6 +19,7 @@ export interface CraftheadRequest {
     identity: string;
     identityType: IdentityKind;
     size: number;
+    armored: boolean;
 }
 
 function stringKindToRequestedKind(kind: string): RequestedKind | null {
@@ -30,6 +32,8 @@ function stringKindToRequestedKind(kind: string): RequestedKind | null {
             return RequestedKind.Cube;
         case "helm":
             return RequestedKind.Helm;
+        case "body":
+            return RequestedKind.Body;
         case "profile":
             return RequestedKind.Profile;
         default:
@@ -43,7 +47,16 @@ export function interpretRequest(request: Request): CraftheadRequest | null {
         url.href = url.href.substring(0, url.href.length - 4)
     }
 
-    let [requestedKindString, identity, sizeString] = url.pathname.split('/').slice(1)
+    let armored = false
+    let sliceAmt = 1
+
+    if (url.pathname.includes("armor/body")) {
+        armored = true
+        sliceAmt = 2
+    }
+
+    let [requestedKindString, identity, sizeString] = url.pathname.split('/').slice(sliceAmt)
+
     let size = parseInt(sizeString, 10);
     if (!size) {
         size = 180 // default, same as Minotar
@@ -71,5 +84,5 @@ export function interpretRequest(request: Request): CraftheadRequest | null {
         return null
     }
 
-    return { requested, identityType, identity, size }
+    return { requested, identityType, identity, size, armored }
 }

--- a/worker/wasm.ts
+++ b/worker/wasm.ts
@@ -1,7 +1,7 @@
 // This is a hack in order to get webpack to play nice with the included WebAssembly module.
 // See https://github.com/rustwasm/wasm-bindgen/issues/700 for more details.
 export async function getRenderer(): Promise<{
-    get_minecraft_head(skin_image: any, size: number, type: string): any;
+    get_rendered_image(skin_image: any, size: number, type: string, armored: boolean): any;
 }> {
     return new Promise((resolve, reject) => {
         // We intentionally ignore the erros here. We know for a fact we are using webpack targeting CommonJS,


### PR DESCRIPTION
Closes #2 
- Adds a render_body() function to skin.rs
- Fixes BodyPart texture coordinates
- Changes function "get_minecraft_head()" to "get_rendered_image()" in lib.rs for clarity
- Adds "/body" and "/armored/body" API routes for body renders (following Minotar API parity)
- Adds "armored" argument to get_rendered_image() for armored body renders

As for why the BodyPart coordinates were wrong, honestly idk, at least from looking at it it seems that Minotar's "skin-spec" that this was probably based on is incorrect, just a suspicion tho. Also, I lined up the pixels in the skin texture with the body renders and this way seems correct. All I know is that in my testing the other code didn't work and this does.

Additionally, I used Minotar's "armored/body" route for body renders with overlays, per Crafthead's URL layout compatibility. Although I don't *love* this path, if keeping Minotar API parity is the goal this should work just fine.