### PR TITLE
Render slim model players correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,14 +28,19 @@ enum RenderType {
     Body,
 }
 
+struct RenderOptions {
+    armored: bool,
+    model: SkinModel,
+}
+
 impl RenderType {
-    fn render(self, img: &MinecraftSkin, size: u32, armored: bool, slim: bool) -> DynamicImage {
+    fn render(self, img: &MinecraftSkin, size: u32, options: RenderOptions) -> DynamicImage {
         match self {
-            RenderType::Avatar => img.get_part(Layer::Bottom, BodyPart::Head, slim)
+            RenderType::Avatar => img.get_part(Layer::Bottom, BodyPart::Head, options.model)
                 .resize(size, size, image::imageops::FilterType::Nearest),
-            RenderType::Helm   => img.get_part(Layer::Both, BodyPart::Head, slim)
+            RenderType::Helm   => img.get_part(Layer::Both, BodyPart::Head, options.model)
                 .resize(size, size, image::imageops::FilterType::Nearest),
-            RenderType::Body   => img.render_body(armored, slim)
+            RenderType::Body   => img.render_body(options)
                 .resize(size, size * 2, image::imageops::FilterType::Nearest),
             RenderType::Cube   => img.render_cube(true, size),
         }
@@ -65,7 +70,11 @@ pub fn get_rendered_image(skin_image: Uint8Array, size: u32, what: String, armor
     match skin_result {
         Ok(skin_img) => {
             let skin = MinecraftSkin::new(skin_img);
-            let rendered = render_type.unwrap().render(&skin, size, armored, slim);
+            let options = match slim {
+                true =>  RenderOptions { armored, model: SkinModel::Slim },
+                false => RenderOptions { armored, model: SkinModel::Regular }
+            };
+            let rendered = render_type.unwrap().render(&skin, size, options);
             let mut result = Vec::with_capacity(1024);
             return match rendered.write_to(&mut result, image::ImageFormat::Png) {
                 Ok(()) => Ok(Uint8Array::from(&result[..])),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,13 +29,13 @@ enum RenderType {
 }
 
 impl RenderType {
-    fn render(self, img: &MinecraftSkin, size: u32, armored: bool) -> DynamicImage {
+    fn render(self, img: &MinecraftSkin, size: u32, armored: bool, slim: bool) -> DynamicImage {
         match self {
-            RenderType::Avatar => img.get_part(Layer::Bottom, BodyPart::Head)
+            RenderType::Avatar => img.get_part(Layer::Bottom, BodyPart::Head, slim)
                 .resize(size, size, image::imageops::FilterType::Nearest),
-            RenderType::Helm   => img.get_part(Layer::Both, BodyPart::Head)
+            RenderType::Helm   => img.get_part(Layer::Both, BodyPart::Head, slim)
                 .resize(size, size, image::imageops::FilterType::Nearest),
-            RenderType::Body   => img.render_body(armored)
+            RenderType::Body   => img.render_body(armored, slim)
                 .resize(size, size * 2, image::imageops::FilterType::Nearest),
             RenderType::Cube   => img.render_cube(true, size),
         }
@@ -53,7 +53,7 @@ fn what_to_render_type(what: String) -> Option<RenderType> {
 }
 
 #[wasm_bindgen]
-pub fn get_rendered_image(skin_image: Uint8Array, size: u32, what: String, armored: bool) -> Result<Uint8Array, JsValue> {
+pub fn get_rendered_image(skin_image: Uint8Array, size: u32, what: String, armored: bool, slim: bool) -> Result<Uint8Array, JsValue> {
     let render_type = what_to_render_type(what);
     if render_type.is_none() {
         return Err(js_sys::Error::new("Invalid render type.").into());
@@ -65,7 +65,7 @@ pub fn get_rendered_image(skin_image: Uint8Array, size: u32, what: String, armor
     match skin_result {
         Ok(skin_img) => {
             let skin = MinecraftSkin::new(skin_img);
-            let rendered = render_type.unwrap().render(&skin, size, armored);
+            let rendered = render_type.unwrap().render(&skin, size, armored, slim);
             let mut result = Vec::with_capacity(1024);
             return match rendered.write_to(&mut result, image::ImageFormat::Png) {
                 Ok(()) => Ok(Uint8Array::from(&result[..])),

--- a/src/skin.rs
+++ b/src/skin.rs
@@ -48,20 +48,20 @@ impl MinecraftSkin {
         }
     }
 
-    pub(crate) fn get_part(&self, layer: Layer, part: BodyPart) -> DynamicImage {
-        let arm_width = match self.version() {
-            MinecraftSkinVersion::Classic => 3,
-            _                             => 4
+    pub(crate) fn get_part(&self, layer: Layer, part: BodyPart, slim: bool) -> DynamicImage {
+        let arm_width = match slim {
+            true  => 3,
+            false => 4
         };
 
         match layer {
             Layer::Both => {
                 if self.version() != MinecraftSkinVersion::Modern && part != Head {
-                    return self.get_part(Layer::Bottom, part);
+                    return self.get_part(Layer::Bottom, part, slim);
                 }
 
-                let mut bottom = self.get_part(Layer::Bottom, part);
-                let mut top = self.get_part(Layer::Top, part);
+                let mut bottom = self.get_part(Layer::Bottom, part, slim);
+                let mut top = self.get_part(Layer::Top, part, slim);
                 apply_minecraft_transparency(&mut top);
                 fast_overlay(&mut bottom, &top, 0, 0);
                 bottom
@@ -73,14 +73,14 @@ impl MinecraftSkin {
                     BodyPart::ArmRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(36, 52, arm_width, 12),
-                            _                            => self.get_part(Bottom, ArmLeft).fliph()
+                            _                            => self.get_part(Bottom, ArmLeft, slim).fliph()
                         }
                     },
-                    BodyPart::ArmLeft => self.0.crop_imm(44, 20, 4, 12),
+                    BodyPart::ArmLeft => self.0.crop_imm(44, 20, arm_width, 12),
                     BodyPart::LegRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(20, 52, 4, 12),
-                            _                            => self.get_part(Bottom, LegLeft).fliph()
+                            _                            => self.get_part(Bottom, LegLeft, slim).fliph()
                         }
                     },
                     BodyPart::LegLeft => self.0.crop_imm(4, 20, 4, 12),
@@ -92,31 +92,31 @@ impl MinecraftSkin {
                     BodyPart::Body => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(20, 36, 8, 12),
-                            _                            => self.get_part(Bottom, Body)
+                            _                            => self.get_part(Bottom, Body, slim)
                         }
                     },
                     BodyPart::ArmLeft => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(52, 52, arm_width, 12),
-                            _                            => self.get_part(Bottom, ArmLeft)
+                            _                            => self.get_part(Bottom, ArmLeft, slim)
                         }
                     },
                     BodyPart::ArmRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(44, 36, arm_width, 12),
-                            _                            => self.get_part(Bottom, ArmLeft).fliph(),
+                            _                            => self.get_part(Bottom, ArmLeft, slim).fliph(),
                         }
                     },
                     BodyPart::LegLeft => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(4, 52, 4, 12),
-                            _                            => self.get_part(Bottom, LegLeft),
+                            _                            => self.get_part(Bottom, LegLeft, slim),
                         }
                     },
                     BodyPart::LegRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(4, 36, 4, 12),
-                            _                            => self.get_part(Bottom, LegLeft).fliph(),
+                            _                            => self.get_part(Bottom, LegLeft, slim).fliph(),
                         }
                     },
                 }
@@ -124,20 +124,30 @@ impl MinecraftSkin {
         }
     }
 
-    pub(crate) fn render_body(&self, overlay: bool) -> DynamicImage {
+    pub(crate) fn render_body(&self, overlay: bool, slim: bool) -> DynamicImage {
         let layer_type = match overlay {
             true  => Layer::Both,
             false => Layer::Bottom
         };
 
-        let mut image = RgbaImage::new(16, 32);
+        let img_width = match slim {
+            true  => 14,
+            false => 16
+        };
 
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Head), 4, 0);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Body), 4, 8);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmLeft), 0, 8);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmRight), 12, 8);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegLeft), 4, 20);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegRight), 8, 20);
+        let arm_width = match slim {
+            true  => 3,
+            false => 4
+        };
+
+        let mut image = RgbaImage::new(img_width, 32);
+
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Head, slim), arm_width, 0);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Body, slim), arm_width, 8);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmLeft, slim), 0, 8);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmRight, slim), arm_width + 8, 8);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegLeft, slim), arm_width, 20);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegRight, slim), arm_width + 4, 20);
 
         DynamicImage::ImageRgba8(image)
     }

--- a/src/skin.rs
+++ b/src/skin.rs
@@ -2,6 +2,7 @@ extern crate image;
 
 use image::{DynamicImage, GenericImageView, Rgba, RgbaImage, imageops};
 use imageproc::geometric_transformations::{Projection, Interpolation, warp_into};
+use crate::RenderOptions;
 use crate::skin::Layer::Bottom;
 use crate::skin::BodyPart::{ArmLeft, LegLeft, Body, Head};
 use crate::utils::{apply_minecraft_transparency, fast_overlay};
@@ -13,6 +14,12 @@ pub(crate) enum MinecraftSkinVersion {
     Classic, // 64x32
     Modern, // 64x64
     Invalid
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum SkinModel {
+    Slim,
+    Regular,
 }
 
 #[derive(Copy, Clone, PartialEq)]
@@ -48,20 +55,20 @@ impl MinecraftSkin {
         }
     }
 
-    pub(crate) fn get_part(&self, layer: Layer, part: BodyPart, slim: bool) -> DynamicImage {
-        let arm_width = match slim {
-            true  => 3,
-            false => 4
+    pub(crate) fn get_part(&self, layer: Layer, part: BodyPart, model: SkinModel) -> DynamicImage {
+        let arm_width = match model {
+            SkinModel::Slim    => 3,
+            SkinModel::Regular => 4
         };
 
         match layer {
             Layer::Both => {
                 if self.version() != MinecraftSkinVersion::Modern && part != Head {
-                    return self.get_part(Layer::Bottom, part, slim);
+                    return self.get_part(Layer::Bottom, part, model);
                 }
 
-                let mut bottom = self.get_part(Layer::Bottom, part, slim);
-                let mut top = self.get_part(Layer::Top, part, slim);
+                let mut bottom = self.get_part(Layer::Bottom, part, model);
+                let mut top = self.get_part(Layer::Top, part, model);
                 apply_minecraft_transparency(&mut top);
                 fast_overlay(&mut bottom, &top, 0, 0);
                 bottom
@@ -73,14 +80,14 @@ impl MinecraftSkin {
                     BodyPart::ArmRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(36, 52, arm_width, 12),
-                            _                            => self.get_part(Bottom, ArmLeft, slim).fliph()
+                            _                            => self.get_part(Bottom, ArmLeft, model).fliph()
                         }
                     },
                     BodyPart::ArmLeft => self.0.crop_imm(44, 20, arm_width, 12),
                     BodyPart::LegRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(20, 52, 4, 12),
-                            _                            => self.get_part(Bottom, LegLeft, slim).fliph()
+                            _                            => self.get_part(Bottom, LegLeft, model).fliph()
                         }
                     },
                     BodyPart::LegLeft => self.0.crop_imm(4, 20, 4, 12),
@@ -92,31 +99,31 @@ impl MinecraftSkin {
                     BodyPart::Body => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(20, 36, 8, 12),
-                            _                            => self.get_part(Bottom, Body, slim)
+                            _                            => self.get_part(Bottom, Body, model)
                         }
                     },
                     BodyPart::ArmLeft => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(52, 52, arm_width, 12),
-                            _                            => self.get_part(Bottom, ArmLeft, slim)
+                            _                            => self.get_part(Bottom, ArmLeft, model)
                         }
                     },
                     BodyPart::ArmRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(44, 36, arm_width, 12),
-                            _                            => self.get_part(Bottom, ArmLeft, slim).fliph(),
+                            _                            => self.get_part(Bottom, ArmLeft, model).fliph(),
                         }
                     },
                     BodyPart::LegLeft => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(4, 52, 4, 12),
-                            _                            => self.get_part(Bottom, LegLeft, slim),
+                            _                            => self.get_part(Bottom, LegLeft, model),
                         }
                     },
                     BodyPart::LegRight => {
                         match self.version() {
                             MinecraftSkinVersion::Modern => self.0.crop_imm(4, 36, 4, 12),
-                            _                            => self.get_part(Bottom, LegLeft, slim).fliph(),
+                            _                            => self.get_part(Bottom, LegLeft, model).fliph(),
                         }
                     },
                 }
@@ -124,30 +131,30 @@ impl MinecraftSkin {
         }
     }
 
-    pub(crate) fn render_body(&self, overlay: bool, slim: bool) -> DynamicImage {
-        let layer_type = match overlay {
+    pub(crate) fn render_body(&self, options: RenderOptions) -> DynamicImage {
+        let layer_type = match options.armored {
             true  => Layer::Both,
             false => Layer::Bottom
         };
 
-        let img_width = match slim {
-            true  => 14,
-            false => 16
+        let img_width = match options.model {
+            SkinModel::Slim    => 14,
+            SkinModel::Regular => 16
         };
 
-        let arm_width = match slim {
-            true  => 3,
-            false => 4
+        let arm_width = match options.model {
+            SkinModel::Slim    => 3,
+            SkinModel::Regular => 4
         };
 
         let mut image = RgbaImage::new(img_width, 32);
 
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Head, slim), arm_width, 0);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Body, slim), arm_width, 8);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmLeft, slim), 0, 8);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmRight, slim), arm_width + 8, 8);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegLeft, slim), arm_width, 20);
-        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegRight, slim), arm_width + 4, 20);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Head, options.model), arm_width, 0);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::Body, options.model), arm_width, 8);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmLeft, options.model), 0, 8);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::ArmRight, options.model), arm_width + 8, 8);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegLeft, options.model), arm_width, 20);
+        imageops::overlay(&mut image, &self.get_part(layer_type, BodyPart::LegRight, options.model), arm_width + 4, 20);
 
         DynamicImage::ImageRgba8(image)
     }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -95,8 +95,7 @@ async function processRequest(skinService: MojangRequestService, interpreted: Cr
         case RequestedKind.Cube:
         case RequestedKind.Body: {
             const skin = await skinService.retrieveSkin(interpreted, gatherer);
-            const slim = skin.headers.get('X-Crafthead-Skin-Model') === 'slim'
-            return renderImage(skin, interpreted.size, interpreted.requested, interpreted.armored, slim);
+            return renderImage(skin, interpreted);
         }
         case RequestedKind.Skin: {
             return await skinService.retrieveSkin(interpreted, gatherer);
@@ -106,8 +105,10 @@ async function processRequest(skinService: MojangRequestService, interpreted: Cr
     }
 }
 
-async function renderImage(skin: Response, size: number, requested: RequestedKind.Avatar | RequestedKind.Helm | RequestedKind.Cube | RequestedKind.Body, armored: boolean, slim: boolean): Promise<Response> {
+async function renderImage(skin: Response, request: CraftheadRequest): Promise<Response> {
+    const {size, requested, armored} = request;
     const destinationHeaders = new Headers(skin.headers);
+    const slim = destinationHeaders.get('X-Crafthead-Skin-Model') === 'slim';
     const [renderer, skinArrayBuffer] = await Promise.all([getRenderer(), skin.arrayBuffer()]);
     const skinBuf = new Uint8Array(skinArrayBuffer);
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -95,7 +95,8 @@ async function processRequest(skinService: MojangRequestService, interpreted: Cr
         case RequestedKind.Cube:
         case RequestedKind.Body: {
             const skin = await skinService.retrieveSkin(interpreted, gatherer);
-            return renderImage(skin, interpreted.size, interpreted.requested, interpreted.armored);
+            const slim = skin.headers.get('X-Crafthead-Skin-Model') === 'slim'
+            return renderImage(skin, interpreted.size, interpreted.requested, interpreted.armored, slim);
         }
         case RequestedKind.Skin: {
             return await skinService.retrieveSkin(interpreted, gatherer);
@@ -105,7 +106,7 @@ async function processRequest(skinService: MojangRequestService, interpreted: Cr
     }
 }
 
-async function renderImage(skin: Response, size: number, requested: RequestedKind.Avatar | RequestedKind.Helm | RequestedKind.Cube | RequestedKind.Body, armored: boolean): Promise<Response> {
+async function renderImage(skin: Response, size: number, requested: RequestedKind.Avatar | RequestedKind.Helm | RequestedKind.Cube | RequestedKind.Body, armored: boolean, slim: boolean): Promise<Response> {
     const destinationHeaders = new Headers(skin.headers);
     const [renderer, skinArrayBuffer] = await Promise.all([getRenderer(), skin.arrayBuffer()]);
     const skinBuf = new Uint8Array(skinArrayBuffer);
@@ -128,7 +129,7 @@ async function renderImage(skin: Response, size: number, requested: RequestedKin
             throw new Error("Unknown requested kind");
     }
 
-    return new Response(renderer.get_rendered_image(skinBuf, size, which, armored), {
+    return new Response(renderer.get_rendered_image(skinBuf, size, which, armored, slim), {
         headers: destinationHeaders
     });
 }

--- a/worker/wasm.ts
+++ b/worker/wasm.ts
@@ -1,7 +1,7 @@
 // This is a hack in order to get webpack to play nice with the included WebAssembly module.
 // See https://github.com/rustwasm/wasm-bindgen/issues/700 for more details.
 export async function getRenderer(): Promise<{
-    get_rendered_image(skin_image: any, size: number, type: string, armored: boolean): any;
+    get_rendered_image(skin_image: any, size: number, type: string, armored: boolean, slim: boolean): any;
 }> {
     return new Promise((resolve, reject) => {
         // We intentionally ignore the erros here. We know for a fact we are using webpack targeting CommonJS,


### PR DESCRIPTION
- Renders slim player models correctly
- Renders slim skins as 14x32 instead of 16x32
- Adds X-Crafthead-Skin-Model header, contains value "slim" or "default"
- Refactors some variables and functions in service.ts for clarity