### PR TITLE
Fix Cloudflare caching armored and non-armored body renders together

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -136,5 +136,5 @@ async function renderImage(skin: Response, request: CraftheadRequest): Promise<R
 }
 
 function getCacheKey(interpreted: CraftheadRequest): string {
-    return `https://crafthead.net/__public${CACHE_BUST}/${interpreted.requested}/${interpreted.identity.toLocaleLowerCase('en-US')}/${interpreted.size}`
+    return `https://crafthead.net/__public${CACHE_BUST}/${interpreted.requested}/${interpreted.armored}/${interpreted.identity.toLocaleLowerCase('en-US')}/${interpreted.size}`
 }


### PR DESCRIPTION
Sorry for yet another pr for you to review. This *should* fix a small issue where Cloudflare would cache the renders for `/body` and `/armor/body` with the same key.

~~I will admit I was not able to test it. I might have been able to actually test it if I pointed a site to it with caching enabled, but honestly idk how workers integrates with the caching API.~~ I tested it, it works wonders. Anyway, thanks for taking the time to review all my pr's, I really appreciate it.