### PR TITLE
Add ability to request skin model by query params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "crafthead",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -161,5 +161,5 @@ async function renderImage(skin: Response, request: CraftheadRequest): Promise<R
 }
 
 function getCacheKey(interpreted: CraftheadRequest): string {
-    return `https://crafthead.net/__public${CACHE_BUST}/${interpreted.requested}/${interpreted.armored}/${interpreted.identity.toLocaleLowerCase('en-US')}/${interpreted.size}`
+    return `https://crafthead.net/__public${CACHE_BUST}/${interpreted.requested}/${interpreted.armored}/${interpreted.model}/${interpreted.identity.toLocaleLowerCase('en-US')}/${interpreted.size}`
 }

--- a/worker/request.ts
+++ b/worker/request.ts
@@ -27,6 +27,7 @@ export interface CraftheadRequest {
     identityType: IdentityKind;
     size: number;
     armored: boolean;
+    model: string | null;
 }
 
 function stringKindToRequestedKind(kind: string): RequestedKind | null {
@@ -57,6 +58,9 @@ export function interpretRequest(request: Request): CraftheadRequest | null {
     if (url.href.endsWith(".png")) {
         url.href = url.href.substring(0, url.href.length - 4)
     }
+
+    let model = url.searchParams.get("model")
+    if (model && !["slim", "default"].includes(model)) model = null
 
     let armored = false
     let sliceAmt = 1
@@ -95,5 +99,5 @@ export function interpretRequest(request: Request): CraftheadRequest | null {
         return null
     }
 
-    return { requested, identityType, identity, size, armored }
+    return { requested, identityType, identity, size, armored, model }
 }

--- a/worker/services/mojang/service.ts
+++ b/worker/services/mojang/service.ts
@@ -73,7 +73,7 @@ export default class MojangRequestService {
                             status: 200,
                             headers: {
                                 'X-Crafthead-Profile-Cache-Hit': lookup.source,
-                                'X-Crafthead-Skin-Model': textureResponse.model || 'default'
+                                'X-Crafthead-Skin-Model': request.model || textureResponse.model || 'default'
                             }
                         });
                     }


### PR DESCRIPTION
Closes #48 

Ex: `https://crafthead.net/body/LadyAgnes?model=slim`

I went with `slim` and `default` as the two options as that's what Mojang uses, if a different string is provided it will fall back to what Mojang's API says is the correct model.