### PR TITLE
feat: add support for fallback IDs

### DIFF
--- a/assets/hytale/Cosmetics/CharacterCreator/Capes.json
+++ b/assets/hytale/Cosmetics/CharacterCreator/Capes.json
@@ -6,6 +6,7 @@
     "Variants": {
       "Neck_Piece": {
         "NameKey": "avatarCustomization.variants.default",
+        "FallbackPartId": "Cape_Trimmed",
         "Model": "Cosmetics/Capes/Cape_Basic.blockymodel",
         "GreyscaleTexture": "Cosmetics/Capes/Cape_Basic_Textures/Cape_Trimmed_Texture.png"
       },
@@ -25,6 +26,7 @@
     "Variants": {
       "Neck_Piece": {
         "NameKey": "avatarCustomization.variants.default",
+        "FallbackPartId": "Cape_Cursebreaker_Gold",
         "Model": "Cosmetics/Capes/Cape_Cursebreaker_Gold.blockymodel",
         "Textures": {
           "White": {
@@ -58,6 +60,7 @@
     "Variants": {
       "Neck_Piece": {
         "NameKey": "avatarCustomization.variants.default",
+        "FallbackPartId": "Cape_Mossy",
         "Model": "Cosmetics/Capes/Cape_Mossy.blockymodel",
         "Textures": {
           "Green": {
@@ -125,6 +128,7 @@
     "Variants": {
       "Neck_Piece": {
         "NameKey": "avatarCustomization.variants.default",
+        "FallbackPartId": "Cape_Basic",
         "Model": "Cosmetics/Capes/Cape_Basic.blockymodel",
         "GreyscaleTexture": "Cosmetics/Capes/Cape_Basic_Textures/Cape_Basic_Texture.png"
       },
@@ -145,6 +149,7 @@
     "Variants": {
       "Neck_Piece": {
         "NameKey": "avatarCustomization.variants.default",
+        "FallbackPartId": "Cape_Leaves",
         "Model": "Cosmetics/Capes/Cape_Leaves.blockymodel",
         "Textures": {
           "Red": {
@@ -191,6 +196,7 @@
     "Variants": {
       "Neck_Piece": {
         "NameKey": "avatarCustomization.variants.default",
+        "FallbackPartId": "Cape_Royal_Leaf",
         "Model": "Cosmetics/Capes/Cape_Royal_Leaf.blockymodel",
         "GreyscaleTexture": "Cosmetics/Capes/Cape_Royal_Leaf_Texture.png"
       },
@@ -210,6 +216,7 @@
     "Variants": {
       "Neck_Piece": {
         "NameKey": "avatarCustomization.variants.default",
+        "FallbackPartId": "Cape_Skeleton_Wizard02",
         "Model": "Cosmetics/Capes/Cape_Skeleton_Wizard02.blockymodel",
         "Textures": {
           "DarkPurple": {
@@ -288,6 +295,7 @@
     "Variants": {
       "Neck_Piece": {
         "NameKey": "avatarCustomization.variants.default",
+        "FallbackPartId": "BigScarf_VoidHunter",
         "Model": "Cosmetics/Capes/Cape_Void_Hero.blockymodel",
         "GreyscaleTexture": "Cosmetics/Capes/Void_Hero_Cape.png"
       },
@@ -340,6 +348,7 @@
     "Variants": {
       "Neck_Piece": {
         "NameKey": "avatarCustomization.variants.default",
+        "FallbackPartId": "Cape_Banneret",
         "Model": "Cosmetics/Capes/Cape_Bannerlord.blockymodel",
         "GreyscaleTexture": "Cosmetics/Capes/Cape_Bannerlord_Texture.png"
       },

--- a/assets/hytale/Cosmetics/CharacterCreator/EmotesInGame.json
+++ b/assets/hytale/Cosmetics/CharacterCreator/EmotesInGame.json
@@ -23,25 +23,35 @@
     "Id": "Tongue",
     "Animation": "Characters/Animations/Taunt/Tongue.blockyanim",
     "Name": "avatarCustomization.emotes.Tongue.name",
-    "Icon": "Icons/Emotes/Tongue.png"
+    "Icon": "Icons/Emotes/Tongue.png",
+    "HideItemInHand": true
   },
   {
     "Id": "Chicken",
     "Animation": "Characters/Animations/Taunt/Chicken.blockyanim",
     "Name": "avatarCustomization.emotes.Chicken.name",
-    "Icon": "Icons/Emotes/Chicken.png"
+    "Icon": "Icons/Emotes/Chicken.png",
+    "HideItemInHand": true
   },
   {
     "Id": "Kill",
     "Animation": "Characters/Animations/Taunt/Kill.blockyanim",
     "Name": "avatarCustomization.emotes.Kill.name",
-    "Icon": "Icons/Emotes/Kill.png"
+    "Icon": "Icons/Emotes/Kill.png",
+    "HideItemInHand": false
   },
   {
     "Id": "Punch",
     "Animation": "Characters/Animations/Taunt/Punch.blockyanim",
     "Name": "avatarCustomization.emotes.Punch.name",
-    "Icon": "Icons/Emotes/Punch.png"
+    "Icon": "Icons/Emotes/Punch.png",
+    "HideItemInHand": true
+  },
+  {
+    "Id": "DabRight",
+    "Animation": "Characters/Animations/Emote/Dab_Left.blockyanim",
+    "Name": "avatarCustomization.emotes.DabRight.name",
+    "Icon": "Icons/Emotes/Dab_Right.png"
   },
   {
     "Id": "DabLeft",
@@ -50,9 +60,60 @@
     "Icon": "Icons/Emotes/Dab_Left.png"
   },
   {
-    "Id": "DabRight",
-    "Animation": "Characters/Animations/Emote/Dab_Left.blockyanim",
-    "Name": "avatarCustomization.emotes.DabRight.name",
-    "Icon": "Icons/Emotes/Dab_Right.png"
+    "Id": "PonderDismissive",
+    "Animation": "Characters/Animations/Emote/Ponder_Dismissive.blockyanim",
+    "Name": "avatarCustomization.emotes.PonderDismissive.name",
+    "Icon": "Icons/Emotes/Ponder.png",
+    "HideItemInHand": true
+  },
+  {
+    "Id": "BlowKiss",
+    "Animation": "Characters/Animations/Emote/Blow_Kiss.blockyanim",
+    "Name": "avatarCustomization.emotes.BlowKiss.name",
+    "Icon": "Icons/Emotes/Blow_Kiss.png",
+    "HideItemInHand": true
+  },
+  {
+    "Id": "Yawn",
+    "Animation": "Characters/Animations/Emote/Yawn.blockyanim",
+    "Name": "avatarCustomization.emotes.Yawn.name",
+    "Icon": "Icons/Emotes/Yawn.png"
+  },
+  {
+    "Id": "Refuse",
+    "Animation": "Characters/Animations/Emote/Shake_Head_No.blockyanim",
+    "Name": "avatarCustomization.emotes.Refuse.name",
+    "Icon": "Icons/Emotes/NegativeNod.png"
+  },
+  {
+    "Id": "Salute",
+    "Animation": "Characters/Animations/Emote/Salute_Chest.blockyanim",
+    "Name": "avatarCustomization.emotes.Salute.name",
+    "Icon": "Icons/Emotes/Salute.png"
+  },
+  {
+    "Id": "HighFive",
+    "Animation": "Characters/Animations/Emote/High_Five.blockyanim",
+    "Name": "avatarCustomization.emotes.HighFive.name",
+    "Icon": "Icons/Emotes/HighFive.png"
+  },
+  {
+    "Id": "Shrug",
+    "Animation": "Characters/Animations/Emote/Shrug.blockyanim",
+    "Name": "avatarCustomization.emotes.Shrug.name",
+    "Icon": "Icons/Emotes/Shrug.png"
+  },
+  {
+    "Id": "DanceBoogie",
+    "Animation": "Characters/Animations/Emote/Dance_Boogie.blockyanim",
+    "Name": "avatarCustomization.emotes.DanceBoogie.name",
+    "Icon": "Icons/Emotes/DanceBoogie.png"
+  },
+  {
+    "Id": "DancePop",
+    "Animation": "Characters/Animations/Emote/Dance_Pop.blockyanim",
+    "Name": "avatarCustomization.emotes.DancePop.name",
+    "Icon": "Icons/Emotes/DancePop.png",
+    "HideItemInHand": true
   }
 ]

--- a/assets/hytale/Cosmetics/CharacterCreator/Gloves.json
+++ b/assets/hytale/Cosmetics/CharacterCreator/Gloves.json
@@ -89,6 +89,7 @@
   {
     "Id": "Hope_Of_Gaia_Gloves",
     "Name": "avatarCustomization.gloves.Hope_Of_Gaia_Gloves.name",
+    "FallbackPartIds": ["GaiaPure_Gloves"],
     "Model": "Cosmetics/Gloves/GaiaPure_Gloves.blockymodel",
     "GreyscaleTexture": "Cosmetics/Gloves/GaiaPure_Gloves_Texture.png",
     "GradientSet": "Pastel_Cotton",
@@ -99,6 +100,7 @@
   {
     "Id": "Gloves_Void_Hero",
     "Name": "avatarCustomization.gloves.Void_Hero_Gloves.name",
+    "FallbackPartIds": ["LongDetailGloves_VoidHunter"],
     "Model": "Cosmetics/Gloves/LongDetail_Gloves.blockymodel",
     "GreyscaleTexture": "Cosmetics/Gloves/LongDetail_Gloves_Textures/LongDetail_Gloves_Void_Hero_Texture.png",
     "GradientSet": "Fantasy_Cotton",

--- a/assets/hytale/Cosmetics/CharacterCreator/HeadAccessory.json
+++ b/assets/hytale/Cosmetics/CharacterCreator/HeadAccessory.json
@@ -504,6 +504,7 @@
   {
     "Id": "Hope_Of_Gaia_Crown",
     "Name": "avatarCustomization.headaccessory.Hope_Of_Gaia_Crown.name",
+    "FallbackPartIds": ["GaiaPure_Crown"],
     "Model": "Cosmetics/Head/GaiaPure_Crown.blockymodel",
     "Entitlements": [
       "game.founder"

--- a/assets/hytale/Cosmetics/CharacterCreator/Overtops.json
+++ b/assets/hytale/Cosmetics/CharacterCreator/Overtops.json
@@ -638,6 +638,7 @@
   {
     "Id": "Jacket_Voyager",
     "Name": "avatarCustomization.overtops.Jacket_Voyager.name",
+    "FallbackPartIds": ["QuiltedLeatherJacket"],
     "Model": "Cosmetics/Overtops/CollaredJacket.blockymodel",
     "GreyscaleTexture": "Cosmetics/Overtops/CollaredJacket_Texture/TopBomber_Texture.png",
     "GradientSet": "Colored_Cotton",
@@ -663,6 +664,7 @@
   {
     "Id": "Hope_Of_GaiaOvertop",
     "Name": "avatarCustomization.overtops.Hope_Of_Gaia_Overtop.name",
+    "FallbackPartIds": ["GaiaPureOvertop"],
     "Model": "Cosmetics/Overtops/GaiaPure_Overtop.blockymodel",
     "GreyscaleTexture": "Cosmetics/Overtops/GaiaPure_Overtop_Texture.png",
     "GradientSet": "Ornamented_Metal",

--- a/assets/hytale/Cosmetics/CharacterCreator/Pants.json
+++ b/assets/hytale/Cosmetics/CharacterCreator/Pants.json
@@ -490,6 +490,7 @@
   {
     "Id": "Hope_Of_Gaia_Skirt",
     "Name": "avatarCustomization.pants.Hope_Of_Gaia_Skirt.name",
+    "FallbackPartIds": ["GaiaPureSkirt"],
     "Model": "Cosmetics/Pants/Skirt_Petals.blockymodel",
     "Textures": {
       "Green": {

--- a/assets/hytale/Cosmetics/CharacterCreator/Shoes.json
+++ b/assets/hytale/Cosmetics/CharacterCreator/Shoes.json
@@ -282,6 +282,7 @@
   {
     "Id": "Boots_Voyager",
     "Name": "avatarCustomization.shoes.Boots_Voyager.name",
+    "FallbackPartIds": ["QuiltedBoots"],
     "Model": "Cosmetics/Shoes/QuiltedBoots.blockymodel",
     "GreyscaleTexture": "Cosmetics/Shoes/QuiltedBoots_Textures/QuiltedBoots_Texture.png",
     "GradientSet": "Colored_Cotton",
@@ -294,6 +295,7 @@
   {
     "Id": "Hope_Of_Gaia_Boots",
     "Name": "avatarCustomization.shoes.Hope_Of_Gaia_Boots.name",
+    "FallbackPartIds": ["GaiaPureBoots"],
     "Model": "Cosmetics/Shoes/GaiaPureBoots.blockymodel",
     "GreyscaleTexture": "Cosmetics/Shoes/GaiaPureBoots_Texture.png",
     "GradientSet": "Ornamented_Metal",

--- a/src/hytale-skin-renderer/src/cosmetic_attachment.rs
+++ b/src/hytale-skin-renderer/src/cosmetic_attachment.rs
@@ -424,22 +424,24 @@ pub fn attach_cosmetic_with_provider(
 	// We will collect "modifiers" from the parts.
 	let modifiers = parts.iter().skip(1).copied().collect::<Vec<&str>>();
 
-	if let Some(def) = registry.get(cosmetic_id) {
-		let registry_key = if registry.contains_key(id_full) {
-			id_full
-		} else {
-			cosmetic_id
-		};
-		let def = registry.get(registry_key).unwrap_or(def);
+	if let Some(resolution) = cosmetics::resolve_part(registry, cosmetic_id) {
+		let def = resolution.def;
+
+		// Renamed part/variant: surface the remap so migrations are observable.
+		if def.id != cosmetic_id {
+			eprintln!("Remapped cosmetic {} -> {}", cosmetic_id, def.id);
+		}
 
 		// 1. Resolve Variant
-
-		// Find if any modifier matches a variant key.
-		let variant_id = def.variants.as_ref().and_then(|variants| {
-			modifiers
-				.iter()
-				.find(|&&m| variants.contains_key(m))
-				.copied()
+		// A variant-level fallback forces its variant; otherwise match a modifier against
+		// a variant key (a stale variant the new part lacks won't match and drops to default).
+		let variant_id = resolution.forced_variant.as_deref().or_else(|| {
+			def.variants.as_ref().and_then(|variants| {
+				modifiers
+					.iter()
+					.find(|&&m| variants.contains_key(m))
+					.copied()
+			})
 		});
 
 		// 2. Resolve Color

--- a/src/hytale-skin-renderer/src/cosmetics.rs
+++ b/src/hytale-skin-renderer/src/cosmetics.rs
@@ -17,6 +17,8 @@ pub struct CosmeticDefinition {
 	pub model: Option<String>,
 	pub greyscale_texture: Option<String>,
 	pub gradient_set: Option<String>,
+	/// Old part ids this part replaces; saved skins referencing them remap here (renamed part).
+	pub fallback_part_ids: Option<Vec<String>>,
 	pub variants: Option<HashMap<String, CosmeticVariant>>,
 	/// Direct textures map for cosmetics like EyePatch
 	/// Key is the color name (e.g., "Black"), value contains texture path
@@ -41,6 +43,8 @@ pub struct CosmeticVariant {
 	pub model: Option<String>,
 	pub greyscale_texture: Option<String>,
 	pub textures: Option<HashMap<String, TextureVariant>>,
+	/// Old part id this variant replaces; saved skins referencing it remap to this part + variant (renamed variant).
+	pub fallback_part_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -82,6 +86,60 @@ pub struct CosmeticRegistry {
 
 pub fn is_valid_cosmetic_id(id: &str) -> bool {
 	!id.is_empty() && id != "null"
+}
+
+/// A part resolved from a category map, possibly via a fallback rename.
+pub struct PartResolution<'a> {
+	pub def: &'a CosmeticDefinition,
+	/// Set only by a variant-level `FallbackPartId` (renamed variant).
+	pub forced_variant: Option<String>,
+}
+
+/// Resolve a saved cosmetic id against a category map, following rename fallbacks on a miss.
+///
+/// Direct hits return immediately (O(1), hot path). The fallback scan only runs when an id
+/// is missing — the rare renamed-part case — so no precomputed reverse map is needed. Old
+/// ids are expected unique per category, so at most one match exists; variant-level is
+/// checked before part-level to keep precedence deterministic if data ever violates that.
+/// Single-hop only: the resolved target is assumed to exist in the current set.
+pub fn resolve_part<'a>(
+	map: &'a HashMap<String, CosmeticDefinition>,
+	cosmetic_id: &str,
+) -> Option<PartResolution<'a>> {
+	if let Some(def) = map.get(cosmetic_id) {
+		return Some(PartResolution {
+			def,
+			forced_variant: None,
+		});
+	}
+
+	for def in map.values() {
+		if let Some(variants) = &def.variants {
+			for (variant_key, variant) in variants {
+				if variant.fallback_part_id.as_deref() == Some(cosmetic_id) {
+					return Some(PartResolution {
+						def,
+						forced_variant: Some(variant_key.clone()),
+					});
+				}
+			}
+		}
+	}
+
+	for def in map.values() {
+		if def
+			.fallback_part_ids
+			.as_ref()
+			.is_some_and(|ids| ids.iter().any(|id| id == cosmetic_id))
+		{
+			return Some(PartResolution {
+				def,
+				forced_variant: None,
+			});
+		}
+	}
+
+	None
 }
 
 impl CosmeticRegistry {
@@ -252,5 +310,95 @@ impl CosmeticRegistry {
 			.or_else(|| self.eyebrows.get(id))
 			.or_else(|| self.mouths.get(id))
 			.or_else(|| self.ears.get(id))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn def(id: &str) -> CosmeticDefinition {
+		CosmeticDefinition {
+			hair_type: None,
+			requires_generic_haircut: None,
+			id: id.to_string(),
+			name: None,
+			model: None,
+			greyscale_texture: None,
+			gradient_set: None,
+			fallback_part_ids: None,
+			variants: None,
+			textures: None,
+			head_accessory_type: None,
+			disable_character_part_category: None,
+		}
+	}
+
+	fn variant(fallback: Option<&str>) -> CosmeticVariant {
+		CosmeticVariant {
+			model: None,
+			greyscale_texture: None,
+			textures: None,
+			fallback_part_id: fallback.map(str::to_string),
+		}
+	}
+
+	fn map_of(defs: Vec<CosmeticDefinition>) -> HashMap<String, CosmeticDefinition> {
+		defs.into_iter().map(|d| (d.id.clone(), d)).collect()
+	}
+
+	#[test]
+	fn resolve_part_direct_hit_has_no_forced_variant() {
+		let map = map_of(vec![def("Boots_Voyager")]);
+		let res = resolve_part(&map, "Boots_Voyager").unwrap();
+		assert_eq!(res.def.id, "Boots_Voyager");
+		assert_eq!(res.forced_variant, None);
+	}
+
+	#[test]
+	fn resolve_part_remaps_renamed_part() {
+		let mut new_part = def("Boots_Voyager");
+		new_part.fallback_part_ids = Some(vec!["QuiltedBoots".to_string()]);
+		let map = map_of(vec![new_part]);
+
+		let res = resolve_part(&map, "QuiltedBoots").unwrap();
+		assert_eq!(res.def.id, "Boots_Voyager");
+		assert_eq!(res.forced_variant, None);
+	}
+
+	#[test]
+	fn resolve_part_remaps_renamed_variant_with_forced_variant() {
+		let mut new_part = def("Cape_Royal_Emissary");
+		let mut variants = HashMap::new();
+		variants.insert("Neck_Piece".to_string(), variant(Some("Cape_Trimmed")));
+		new_part.variants = Some(variants);
+		let map = map_of(vec![new_part]);
+
+		let res = resolve_part(&map, "Cape_Trimmed").unwrap();
+		assert_eq!(res.def.id, "Cape_Royal_Emissary");
+		assert_eq!(res.forced_variant.as_deref(), Some("Neck_Piece"));
+	}
+
+	#[test]
+	fn resolve_part_unknown_id_returns_none() {
+		let map = map_of(vec![def("Boots_Voyager")]);
+		assert!(resolve_part(&map, "DoesNotExist").is_none());
+	}
+
+	#[test]
+	fn resolve_part_prefers_variant_level_over_part_level() {
+		let mut part_level = def("Part_Level_Target");
+		part_level.fallback_part_ids = Some(vec!["OldId".to_string()]);
+
+		let mut variant_level = def("Variant_Level_Target");
+		let mut variants = HashMap::new();
+		variants.insert("V1".to_string(), variant(Some("OldId")));
+		variant_level.variants = Some(variants);
+
+		let map = map_of(vec![part_level, variant_level]);
+
+		let res = resolve_part(&map, "OldId").unwrap();
+		assert_eq!(res.def.id, "Variant_Level_Target");
+		assert_eq!(res.forced_variant.as_deref(), Some("V1"));
 	}
 }

--- a/src/hytale-skin-renderer/src/render_pipeline.rs
+++ b/src/hytale-skin-renderer/src/render_pipeline.rs
@@ -28,7 +28,9 @@ fn resolve_gradient_texture_path(
 	let parts: Vec<&str> = full_id.split('.').collect();
 	let color_part = if parts.len() >= 2 { parts[1] } else { parts[0] };
 
-	let def = registry_map.get(id)?;
+	// Fallback-aware so a renamed part still resolves its gradient set; colour
+	// (parsed positionally above) carries over unchanged.
+	let def = cosmetics::resolve_part(registry_map, id)?.def;
 	let gradient_set_id = def.gradient_set.as_deref().or(default_set)?;
 
 	if let Some(set) = gradient_sets.get(gradient_set_id) {
@@ -558,7 +560,9 @@ impl BodyRenderer {
 		// Head Accessory
 		if let Some(ref id_full) = config.skin.head_accessory {
 			let cosmetic_id = id_full.split('.').next().unwrap();
-			if let Some(def) = self.registry.head_accessories.get(cosmetic_id) {
+			if let Some(def) =
+				cosmetics::resolve_part(&self.registry.head_accessories, cosmetic_id).map(|r| r.def)
+			{
 				// Determine culling mode from accessory definition
 				self.active_head_accessory_culling = Some(
 					if def.disable_character_part_category.as_deref() == Some("Haircut") {

--- a/src/hytale-skin-renderer/src/skin.rs
+++ b/src/hytale-skin-renderer/src/skin.rs
@@ -133,7 +133,9 @@ impl ResolvedTints {
 				parts[0] // fallback or handle as "no color"? logic was just last() before
 			};
 
-			let def = registry_map.get(id)?;
+			// Fallback-aware so a renamed part still resolves its gradient set; colour
+			// (parsed positionally above) carries over unchanged.
+			let def = crate::cosmetics::resolve_part(registry_map, id)?.def;
 
 			let gradient_set_id = def.gradient_set.as_deref().or(default_set)?;
 
@@ -309,6 +311,7 @@ mod tests {
 				name: None,
 				model: None,
 				greyscale_texture: None,
+				fallback_part_ids: None,
 				variants: None,
 				textures: None,
 				head_accessory_type: None,
@@ -327,6 +330,7 @@ mod tests {
 				name: None,
 				model: None,
 				greyscale_texture: None,
+				fallback_part_ids: None,
 				variants: None,
 				textures: None,
 				head_accessory_type: None,
@@ -345,6 +349,7 @@ mod tests {
 				name: None,
 				model: None,
 				greyscale_texture: None,
+				fallback_part_ids: None,
 				variants: None,
 				textures: None,
 				head_accessory_type: None,
@@ -363,6 +368,7 @@ mod tests {
 				name: None,
 				model: None,
 				greyscale_texture: None,
+				fallback_part_ids: None,
 				variants: None,
 				textures: None,
 				head_accessory_type: None,
@@ -396,6 +402,7 @@ mod tests {
 				name: None,
 				model: None,
 				greyscale_texture: None,
+				fallback_part_ids: None,
 				variants: None,
 				textures: None,
 				head_accessory_type: None,
@@ -426,6 +433,63 @@ mod tests {
 		// Should resolve to the path specified in the gradient set, NOT "Fantasy_Cotton_Dark/Red.png"
 		assert!(tints
 			.cape_color
+			.as_ref()
+			.unwrap()
+			.ends_with("TintGradients/Dark_Fantasy_Cotton/Red.png"));
+	}
+
+	#[test]
+	fn test_resolve_tints_carries_colour_through_fallback() {
+		// Saved skin references the old id; the new part lists it in FallbackPartIds.
+		let json = r#"{
+            "skin": {
+                "bodyCharacteristic": "Default.10",
+                "shoes": "QuiltedBoots.Red"
+            }
+        }"#;
+
+		let config = SkinConfig::from_str(json).unwrap();
+		let mut registry = mock_registry();
+
+		registry.shoes.insert(
+			"Boots_Voyager".to_string(),
+			CosmeticDefinition {
+				id: "Boots_Voyager".to_string(),
+				gradient_set: Some("Fantasy_Cotton_Dark".to_string()),
+				fallback_part_ids: Some(vec!["QuiltedBoots".to_string()]),
+				hair_type: None,
+				requires_generic_haircut: None,
+				name: None,
+				model: None,
+				greyscale_texture: None,
+				variants: None,
+				textures: None,
+				head_accessory_type: None,
+				disable_character_part_category: None,
+			},
+		);
+
+		let mut gradients = HashMap::new();
+		gradients.insert(
+			"Red".to_string(),
+			crate::cosmetics::GradientDefinition {
+				base_color: None,
+				texture: Some("TintGradients/Dark_Fantasy_Cotton/Red.png".to_string()),
+			},
+		);
+		registry.gradient_sets.insert(
+			"Fantasy_Cotton_Dark".to_string(),
+			crate::cosmetics::GradientSet {
+				id: Some("Fantasy_Cotton_Dark".to_string()),
+				gradients,
+			},
+		);
+
+		let tints = ResolvedTints::from_skin_config(&config, Path::new("assets"), &registry);
+
+		// Colour (Red) carries over and resolves via the renamed part's gradient set.
+		assert!(tints
+			.shoes_color
 			.as_ref()
 			.unwrap()
 			.ends_with("TintGradients/Dark_Fantasy_Cotton/Red.png"));

--- a/src/worker/services/hytale/cosmetic-registry.ts
+++ b/src/worker/services/hytale/cosmetic-registry.ts
@@ -151,9 +151,25 @@ async function ensureInitialized(): Promise<void> {
 }
 
 /**
- * Look up a cosmetic definition by slot and ID
+ * A definition resolved from a slot, possibly via a rename fallback.
  */
-export async function getDefinition(slot: CosmeticSlot, id: string): Promise<CosmeticDefinition | null> {
+export interface ResolvedPart {
+	definition: CosmeticDefinition;
+	// Set only by a variant-level FallbackPartId (renamed variant).
+	forcedVariant?: string;
+}
+
+/**
+ * Resolve a saved cosmetic id within a slot, following rename fallbacks on a miss.
+ *
+ * Mirrors the WASM-side `resolve_part`: direct hits return immediately, and only on a
+ * miss do we scan the slot for a renamed part (`FallbackPartIds`) or renamed variant
+ * (`FallbackPartId`, variant-level checked first for deterministic precedence). Keeping
+ * this in sync matters because this layer decides which model/texture/gradient assets get
+ * bundled for WASM — without it, a renamed part's assets are never fetched and WASM's own
+ * remap resolves to a part whose files are absent.
+ */
+export async function resolvePart(slot: CosmeticSlot, id: string): Promise<ResolvedPart | null> {
 	await ensureInitialized();
 
 	const fileName = SLOT_TO_FILE[slot];
@@ -164,7 +180,29 @@ export async function getDefinition(slot: CosmeticSlot, id: string): Promise<Cos
 	if (!slotIndex) {
 		return null;
 	}
-	return slotIndex.get(id) ?? null;
+
+	const direct = slotIndex.get(id);
+	if (direct) {
+		return { definition: direct };
+	}
+
+	for (const definition of slotIndex.values()) {
+		if (definition.Variants) {
+			for (const [variantKey, variant] of Object.entries(definition.Variants)) {
+				if (variant.FallbackPartId === id) {
+					return { definition, forcedVariant: variantKey };
+				}
+			}
+		}
+	}
+
+	for (const definition of slotIndex.values()) {
+		if (definition.FallbackPartIds?.includes(id)) {
+			return { definition };
+		}
+	}
+
+	return null;
 }
 
 /**
@@ -213,12 +251,22 @@ export async function resolveCosmetic(
 	}
 
 	const parsed = parseSkinValue(value);
-	const definition = await getDefinition(slot, parsed.id);
+	const resolved = await resolvePart(slot, parsed.id);
 
-	if (!definition) {
+	if (!resolved) {
 		console.warn(`Cosmetic definition not found: ${slot}/${parsed.id}`);
 		return null;
 	}
+
+	const { definition, forcedVariant } = resolved;
+	if (definition.Id !== parsed.id) {
+		console.warn(`Remapped cosmetic ${slot}/${parsed.id} -> ${definition.Id}`);
+	}
+
+	// A variant-level fallback forces its variant; otherwise keep the saved variant only if
+	// the new part still defines it (else fall through to default), so colour still carries.
+	const effectiveVariant = forcedVariant
+		?? (parsed.variant && definition.Variants?.[parsed.variant] ? parsed.variant : undefined);
 
 	// Determine model and texture paths
 	let modelPath: string | null = null;
@@ -227,8 +275,8 @@ export async function resolveCosmetic(
 	let gradientSetId: string | null = definition.GradientSet ?? null;
 
 	// Check for variant
-	if (parsed.variant && definition.Variants) {
-		const variant = definition.Variants[parsed.variant];
+	if (effectiveVariant && definition.Variants) {
+		const variant = definition.Variants[effectiveVariant];
 		if (variant) {
 			modelPath = variant.Model ?? definition.Model ?? null;
 
@@ -290,14 +338,14 @@ export async function resolveCosmetic(
 
 	return {
 		slot,
-		id: parsed.id,
+		id: definition.Id,
 		modelPath: fullModelPath && !basePlayerAssets.has(fullModelPath) ? fullModelPath : null,
 		texturePath: fullTexturePath && !basePlayerAssets.has(fullTexturePath) ? fullTexturePath : null,
 		gradientSetId,
 		colorId,
 		gradientTexturePath: gradientTexturePath ? `Common/${gradientTexturePath}` : null,
 		baseColor,
-		variant: parsed.variant,
+		variant: effectiveVariant,
 	};
 }
 

--- a/src/worker/services/hytale/types.ts
+++ b/src/worker/services/hytale/types.ts
@@ -49,6 +49,8 @@ export interface CosmeticVariant {
 	Icon?: string;
 	BaseColor?: string[];
 	Textures?: Record<string, CosmeticTexture>;
+	// Old part id this variant replaces; saved skins referencing it remap here (renamed variant).
+	FallbackPartId?: string;
 }
 
 /**
@@ -74,6 +76,8 @@ export interface CosmeticDefinition {
 	Variants?: Record<string, CosmeticVariant>;
 	Textures?: Record<string, CosmeticTexture>;
 	Entitlements?: string[];
+	// Old part ids this part replaces; saved skins referencing them remap here (renamed part).
+	FallbackPartIds?: string[];
 }
 
 /**

--- a/test/cosmetic-registry.test.ts
+++ b/test/cosmetic-registry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCosmetic, resolvePart } from '../src/worker/services/hytale/cosmetic-registry';
+
+// Backed by the real bundled CharacterCreator JSON: Shoes.json renames QuiltedBoots ->
+// Boots_Voyager (part level), Capes.json renames Cape_Trimmed -> Cape_Royal_Emissary's
+// Neck_Piece variant (variant level).
+describe('cosmetic fallback resolution', () => {
+	it('resolves a renamed part with no forced variant', async () => {
+		const resolved = await resolvePart('shoes', 'QuiltedBoots');
+		expect(resolved?.definition.Id).toBe('Boots_Voyager');
+		expect(resolved?.forcedVariant).toBeUndefined();
+	});
+
+	it('resolves a renamed variant to its new part plus the forced variant', async () => {
+		const resolved = await resolvePart('cape', 'Cape_Trimmed');
+		expect(resolved?.definition.Id).toBe('Cape_Royal_Emissary');
+		expect(resolved?.forcedVariant).toBe('Neck_Piece');
+	});
+
+	it('returns null for an unknown id', async () => {
+		expect(await resolvePart('shoes', 'DoesNotExist')).toBeNull();
+	});
+
+	it('selects the renamed part assets and carries colour through resolveCosmetic', async () => {
+		const cosmetic = await resolveCosmetic('shoes', 'QuiltedBoots.Black');
+		expect(cosmetic).not.toBeNull();
+		// Assets fetched for WASM must point at the new part, with the saved colour kept.
+		expect(cosmetic?.id).toBe('Boots_Voyager');
+		expect(cosmetic?.modelPath).toContain('Cosmetics/Shoes/QuiltedBoots.blockymodel');
+		expect(cosmetic?.colorId).toBe('Black');
+	});
+});


### PR DESCRIPTION
Hytale update 6 is adding a migration path for cosmetics by utilizing these fallback ID fields. This changes the cosmetic registry to do proper resolution to find the needed files. 